### PR TITLE
Add pre-commit GitHub Action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run at 1:00 every day
+    - cron: 0 1 * * *
+
+permissions: {}
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
## Summary\n- add a pre-commit GitHub Action workflow to run hooks on PRs and on a schedule\n\n## Testing\n- not run (action only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds a linting workflow; minimal impact beyond potentially failing builds if hooks surface new issues.
> 
> **Overview**
> Adds a new GitHub Actions `Lint` workflow that runs `pre-commit` hooks via `pre-commit/action@v3.0.1`.
> 
> The workflow triggers on `pull_request` and `push` to `main`, plus a daily cron run, and uses checkout with `persist-credentials: false` and empty `permissions` for least-privilege.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 369d196bdc0dd396a19ad0252d140b2c88763983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->