### PR TITLE
Add completion-lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,15 @@ jobs:
           persist-credentials: false
 
       - uses: pre-commit/action@v3.0.1
+
+  completion-lint:
+    needs: pre-commit
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix job status
+        run: |-
+          if ! ${{ needs.pre-commit.result == 'success' }}; then
+            echo "One or more matrix jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
Add completion-lint job to lint workflow so it shows up in PR checks.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow orchestration and do not affect runtime code. Main risk is CI misconfiguration (e.g., the new job failing unexpectedly), which would only block merges until adjusted.
> 
> **Overview**
> Adds a new `completion-lint` job to `.github/workflows/lint.yml` that *always runs* after `pre-commit` and fails when `pre-commit` did not succeed, creating a single, consistent PR check representing lint status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1490d1f2ebb07f462e07c04e47572fa1afc6951. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->