### PR TITLE
Add ci.yml with completion-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+---
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Audit formula
+        run: brew audit --strict --online vws-cli.rb
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  completion-ci:
+    needs: build
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix job status
+        run: |-
+          if ! ${{ needs.build.result == 'success' }}; then
+            echo "One or more matrix jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
Add ci.yml workflow with completion-ci, so all projects have both completion-lint and completion-ci.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds CI checks; low blast radius aside from potential new CI failures if the formula audit is stricter than current expectations.
> 
> **Overview**
> Adds a new `.github/workflows/ci.yml` workflow that runs on pushes/PRs to `master` and performs a Homebrew `brew audit --strict --online` for `vws-cli.rb`.
> 
> Includes a `completion-ci` job that always runs after `build` and fails the workflow if the upstream job did not succeed, mirroring the existing completion pattern used in `lint.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f51a7181df591ca2971eaee35c822beb93d15864. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->