### PR TITLE
Fix brew audit by using formula name instead of path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Audit formula
-        run: brew audit --strict --online vws-cli.rb
+        run: brew audit --strict --online vws-cli
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Homebrew has disabled calling `brew audit` with a file path. This updates the CI workflow to use the formula name `vws-cli` instead of the file path `vws-cli.rb`, fixing the CI failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates how `brew audit` is invoked; no product code or runtime behavior is affected.
> 
> **Overview**
> Updates the CI workflow to run `brew audit` against the formula name `vws-cli` instead of the file path `vws-cli.rb`, aligning with Homebrew’s updated behavior and preventing audit step failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6de8ae2e9cde65298fc46955c084776debf5b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->